### PR TITLE
Migrate from master-slave terminology

### DIFF
--- a/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_internal/vcs/git.py
+++ b/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_internal/vcs/git.py
@@ -169,7 +169,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.check_rev_options(dest, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
@@ -558,9 +558,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3086,9 +3086,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3098,7 +3098,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.